### PR TITLE
Rename Lwjgl backend files to Gdx

### DIFF
--- a/src/main/java/com/katzstudio/kreativity/ui/backend/gdx/KrGdxBackend.java
+++ b/src/main/java/com/katzstudio/kreativity/ui/backend/gdx/KrGdxBackend.java
@@ -1,4 +1,4 @@
-package com.katzstudio.kreativity.ui.backend.lwjgl3;
+package com.katzstudio.kreativity.ui.backend.gdx;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
@@ -19,26 +19,26 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * This backed works with the libgdx Lwjgl3 backend.
+ * This backend works with libgdx.
  */
-public class KrLwjgl3Backend implements KrBackend {
+public class KrGdxBackend implements KrBackend {
 
     private final Map<Color, Drawable> drawableCache = new HashMap<>();
 
-    private final KrLwjgl3Renderer renderer;
+    private final KrGdxRenderer renderer;
 
-    private final KrLwjgl3FontMetrics fontMetrics;
+    private final KrGdxFontMetrics fontMetrics;
 
-    private final KrLwjgl3InputSource inputSource;
+    private final KrGdxInputSource inputSource;
 
     private final Clipboard clipboard;
 
     private KrCursor currentCursor;
 
-    public KrLwjgl3Backend() {
-        renderer = new KrLwjgl3Renderer();
-        fontMetrics = new KrLwjgl3FontMetrics();
-        inputSource = new KrLwjgl3InputSource();
+    public KrGdxBackend() {
+        renderer = new KrGdxRenderer();
+        fontMetrics = new KrGdxFontMetrics();
+        inputSource = new KrGdxInputSource();
         clipboard = Gdx.app.getClipboard();
     }
 

--- a/src/main/java/com/katzstudio/kreativity/ui/backend/gdx/KrGdxFontMetrics.java
+++ b/src/main/java/com/katzstudio/kreativity/ui/backend/gdx/KrGdxFontMetrics.java
@@ -1,4 +1,4 @@
-package com.katzstudio.kreativity.ui.backend.lwjgl3;
+package com.katzstudio.kreativity.ui.backend.gdx;
 
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
@@ -6,9 +6,9 @@ import com.badlogic.gdx.math.Rectangle;
 import com.katzstudio.kreativity.ui.KrFontMetrics;
 
 /**
- * {@link KrFontMetrics} implementation for the libgdx lwjgl3 backend
+ * {@link KrFontMetrics} implementation for the libgdx backend
  */
-public class KrLwjgl3FontMetrics extends KrFontMetrics {
+public class KrGdxFontMetrics extends KrFontMetrics {
 
     private GlyphLayout layout = new GlyphLayout();
 

--- a/src/main/java/com/katzstudio/kreativity/ui/backend/gdx/KrGdxInputSource.java
+++ b/src/main/java/com/katzstudio/kreativity/ui/backend/gdx/KrGdxInputSource.java
@@ -1,4 +1,4 @@
-package com.katzstudio.kreativity.ui.backend.lwjgl3;
+package com.katzstudio.kreativity.ui.backend.gdx;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
@@ -17,9 +17,9 @@ import java.util.List;
 import static com.badlogic.gdx.Input.Keys.*;
 
 /**
- * {@link KrInputSource} implementation for libgdx lwjgl3 backend.
+ * {@link KrInputSource} implementation for the libgdx backend.
  */
-public class KrLwjgl3InputSource extends InputAdapter implements KrInputSource {
+public class KrGdxInputSource extends InputAdapter implements KrInputSource {
 
     private static final float KEY_REPEAT_INITIAL_TIME = 0.4f;
 
@@ -63,7 +63,7 @@ public class KrLwjgl3InputSource extends InputAdapter implements KrInputSource {
 
     private Vector2 mousePosition = new Vector2();
 
-    public KrLwjgl3InputSource() {
+    public KrGdxInputSource() {
         // TODO: investigate pointer offset on MAC OSX. Compensating here with a small hack
         if (((String) System.getProperties().get("os.name")).contains("Mac")) {
             inputOffsetX = -4;

--- a/src/main/java/com/katzstudio/kreativity/ui/backend/gdx/KrGdxRenderer.java
+++ b/src/main/java/com/katzstudio/kreativity/ui/backend/gdx/KrGdxRenderer.java
@@ -1,4 +1,4 @@
-package com.katzstudio.kreativity.ui.backend.lwjgl3;
+package com.katzstudio.kreativity.ui.backend.gdx;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -22,9 +22,9 @@ import lombok.Setter;
 import static com.katzstudio.kreativity.ui.KrToolkit.getDefaultToolkit;
 
 /**
- * {@link KrRenderer} implementation for the libgdx lwjgl3 backend
+ * {@link KrRenderer} implementation for the libgdx backend
  */
-public class KrLwjgl3Renderer extends KrRenderer {
+public class KrGdxRenderer extends KrRenderer {
 
     private final RenderMode spriteBatchRenderMode;
 
@@ -56,7 +56,7 @@ public class KrLwjgl3Renderer extends KrRenderer {
 
     @Getter private float opacity = 1;
 
-    public KrLwjgl3Renderer() {
+    public KrGdxRenderer() {
         spriteBatch = new SpriteBatch(100);
         shapeRenderer = new ShapeRenderer(100);
         shapeRenderer.setAutoShapeType(true);

--- a/src/test/java/com/katzstudio/kreativity/ui/demo/RendererDemo.java
+++ b/src/test/java/com/katzstudio/kreativity/ui/demo/RendererDemo.java
@@ -4,7 +4,7 @@ import com.badlogic.gdx.Game;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.graphics.Color;
-import com.katzstudio.kreativity.ui.backend.lwjgl3.KrLwjgl3Renderer;
+import com.katzstudio.kreativity.ui.backend.gdx.KrGdxRenderer;
 import com.katzstudio.kreativity.ui.render.KrColorBrush;
 import com.katzstudio.kreativity.ui.render.KrRenderer;
 
@@ -30,7 +30,7 @@ public class RendererDemo extends Game {
         gl.glDepthMask(true);
         gl.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         gl.glClearColor(0.2f, 0.2f, 0.2f, 1.0f);
-        renderer = new KrLwjgl3Renderer();
+        renderer = new KrGdxRenderer();
     }
 
     @Override

--- a/src/test/java/com/katzstudio/kreativity/ui/demo/UiDemo.java
+++ b/src/test/java/com/katzstudio/kreativity/ui/demo/UiDemo.java
@@ -12,7 +12,7 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.katzstudio.kreativity.ui.*;
-import com.katzstudio.kreativity.ui.backend.lwjgl3.KrLwjgl3Backend;
+import com.katzstudio.kreativity.ui.backend.gdx.KrGdxBackend;
 import com.katzstudio.kreativity.ui.component.*;
 import com.katzstudio.kreativity.ui.component.KrMenu.KrMenuItem;
 import com.katzstudio.kreativity.ui.component.KrMenu.KrMenuItemSeparator;
@@ -81,7 +81,7 @@ public class UiDemo extends Game {
         gl.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         gl.glClearColor(0.3f, 0.3f, 0.3f, 1);
 
-        KrToolkit.initialize(new KrLwjgl3Backend());
+        KrToolkit.initialize(new KrGdxBackend());
         Gdx.input.setInputProcessor((InputAdapter) getDefaultToolkit().getInputSource());
         canvas = KrToolkit.getDefaultToolkit().getCanvas();
 


### PR DESCRIPTION
The following screenshot is using the lwjgl2 backend
![Screenshot from 2021-03-01 22-41-02](https://user-images.githubusercontent.com/1824878/109583835-4b075700-7adf-11eb-91a2-5dca14c27a21.png)


Closes #119 